### PR TITLE
support python 3 and use java -jar to start jython

### DIFF
--- a/bin/nlgserv
+++ b/bin/nlgserv
@@ -29,7 +29,7 @@ if __name__=="__main__":
       server = nlgserv.start_server(host, port)
 
    try:
-      print "Server started. Press Ctrl+C to stop."
+      print("Server started. Press Ctrl+C to stop.")
       server.wait()
    except KeyboardInterrupt:
       nlgserv.stop_server(server)

--- a/nlgserv/__init__.py
+++ b/nlgserv/__init__.py
@@ -1,1 +1,1 @@
-from _controller import start_server, stop_server
+from nlgserv._controller import start_server, stop_server

--- a/nlgserv/_controller.py
+++ b/nlgserv/_controller.py
@@ -14,8 +14,9 @@ def start_server(host, port, output=None, error=None):
     if error == None:
         error = open(os.devnull, "w")
 
-    print "Starting nlgserv on %s:%s" % (host, port)
-    server_instance = Popen([os.path.join(os.path.dirname(__file__),"jython.jar"),
+    print("Starting nlgserv on %s:%s" % (host, port))
+    server_instance = Popen(["java", "-jar",
+                             os.path.join(os.path.dirname(__file__),"jython.jar"),
                              os.path.join(os.path.dirname(__file__),"_server.py"),
                              host,
                              str(port)],
@@ -33,6 +34,6 @@ def stop_server(server_instance):
     This function is blocking, and will wait until the PG is dead before releasing
     control.
     """
-    print "Shutting down nlgserv..."
+    print("Shutting down nlgserv...")
     os.killpg(server_instance.pid, SIGTERM)
     server_instance.wait()

--- a/nlgserv/_server.py
+++ b/nlgserv/_server.py
@@ -25,8 +25,8 @@ def process_generate_sentence_request():
     try:
         # Generate the sentence from the JSON payload.
         return realiser.realiseSentence(generate_sentence(request.json))
-    except Exception, e:
-        print e
+    except Exception as e:
+        print(e)
         response.status = 400
         # If any exceptions are thrown, set status to 400, and return the error string
         return str(e)
@@ -180,5 +180,5 @@ def process_features(element, f_spec):
 if __name__=="__main__":
     host = sys.argv[1]
     port = int(sys.argv[2])
-    print "Starting to run on %s, port %s" % (host, port)
+    print("Starting to run on %s, port %s" % (host, port))
     run(host=host, port=port)

--- a/nlgserv/tests/server-test.py
+++ b/nlgserv/tests/server-test.py
@@ -11,18 +11,18 @@ nlgserv = None
 
 def setUpModule():
     global nlgserv
-    print "Starting up nlgserv..."
+    print("Starting up nlgserv...")
     nlgserv = subprocess.Popen([os.path.join(os.path.dirname(__file__),"../jython.jar"), os.path.join(os.path.dirname(__file__), "../_server.py"), "localhost", "8080"],
                                stdin=subprocess.PIPE,
                                stdout=open(os.path.join(os.path.dirname(__file__), "nlgserv.stdout.log"), "w+"),
                                stderr=open(os.path.join(os.path.dirname(__file__), "nlgserv.stderr.log"), "w+"),
                                preexec_fn=os.setsid)
     sleep(60) # It needs longer now it's loading from the standalone package...
-    print "Commencing testing..."
+    print("Commencing testing...")
     
 def tearDownModule():
     global nlgserv
-    print "Shutting down nlgserv..."
+    print("Shutting down nlgserv...")
     os.killpg(nlgserv.pid, subprocess.signal.SIGTERM)
     nlgserv.wait()
     

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="nlgserv",
-    version="0.2.3",
+    version="0.2.4",
     author="Darren Richardson",
     packages=["nlgserv","nlgserv.tests"],
     package_data={"nlgserv":["simplenlg.jar","jython.jar"]},


### PR DESCRIPTION
- add support for python 3 by using print as a function, using "except Exception as e", and using absolute imports
- use "java -jar" to start "jython.jar", needed for OS X
- minor version bump from 0.2.3 to 0.2.4